### PR TITLE
Fixing the watch on 9anime button on MAL

### DIFF
--- a/src/site_integration/myanimelist.js
+++ b/src/site_integration/myanimelist.js
@@ -50,7 +50,7 @@ let getAnimeLink = (animeName, html) => {
     const searchArr = doc.querySelectorAll(".info > a.name");
     for (let i = 0; i < searchArr.length; i++) {
         if (searchArr[i].innerText === animeName) {
-            const url = searchArr[i].href;
+            const url = "https://9anime.to" + searchArr[i].pathname;
             return isUrl(url) ? url : "";
         }
     }


### PR DESCRIPTION
The path is build from a different array field and the 9anime base url

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/lap00zza/9anime-Companion/blob/rewrite/typescript/.github/CONTRIBUTING.md#pull-requests
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**The PR fulfills these requirements:**

- [x] All tests are passing
- [ ] New/updated tests are included

**Describe you PR:**

Related to #133
Fixes the issue with the 'watch on 9anime' button on MAL – the base URL in searchArr was the MAL url (and I don't really know why). I fixed it by using a different field (with the relative path url) and adding the 9anime base url.

Tell me if that's ok or something else needs to be done.
